### PR TITLE
Fix CI by resolving django_cairn path.

### DIFF
--- a/.idea/django_cairn.iml
+++ b/.idea/django_cairn.iml
@@ -20,6 +20,7 @@
       <excludeFolder url="file://$MODULE_DIR$/htmlcov" />
       <excludeFolder url="file://$MODULE_DIR$/staticfiles" />
     </content>
+    <orderEntry type="jdk" jdkName="Python 3.10 (django-cairn)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
   <component name="PackageRequirementsSettings">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,4 +3,5 @@
   <component name="JavaScriptSettings">
     <option name="languageLevel" value="ES6" />
   </component>
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.10 (django-cairn)" project-jdk-type="Python SDK" />
 </project>

--- a/README.md
+++ b/README.md
@@ -12,18 +12,18 @@ The current plan is as follows:
 4. Determine data model.
 6. Implement views and templates.
 7. `<deployment shenanigans>`
-8. Research RSS ingestion solution. 
+8. Research RSS ingestion solution.
 9. Research content review solution.
 10. `<draw rest of owl>`
 
 If you'd like to help, I'd love to have it. But as you can see, things are
 still a bit mushy.
 
-If you're still interested, add a comment to 
+If you're still interested, add a comment to
 [Issue #2](https://github.com/tim-schilling/django-cairn/issues/2).
 
 If you have specific ideas for the site, feel free to share them with me
-how you're most comfortable. The best public location is currently the 
+how you're most comfortable. The best public location is currently the
 [welcome discussion](https://github.com/tim-schilling/django-cairn/discussions/1).
 
 

--- a/local.yml
+++ b/local.yml
@@ -7,7 +7,7 @@ volumes:
 services:
   django:
     build:
-      context: django_cairn
+      context: .
       dockerfile: compose/local/django/Dockerfile
     image: django_cairn_local_django
     container_name: django_cairn_local_django
@@ -24,7 +24,7 @@ services:
 
   postgres:
     build:
-      context: django_cairn
+      context: .
       dockerfile: compose/production/postgres/Dockerfile
     image: django_cairn_production_postgres
     container_name: django_cairn_local_postgres
@@ -38,7 +38,7 @@ services:
     image: django_cairn_local_docs
     container_name: django_cairn_local_docs
     build:
-      context: django_cairn
+      context: .
       dockerfile: compose/local/docs/Dockerfile
     env_file:
       - .envs/.local/.django

--- a/local.yml
+++ b/local.yml
@@ -7,7 +7,7 @@ volumes:
 services:
   django:
     build:
-      context: django_cairn2
+      context: django_cairn
       dockerfile: compose/local/django/Dockerfile
     image: django_cairn_local_django
     container_name: django_cairn_local_django
@@ -24,7 +24,7 @@ services:
 
   postgres:
     build:
-      context: django_cairn2
+      context: django_cairn
       dockerfile: compose/production/postgres/Dockerfile
     image: django_cairn_production_postgres
     container_name: django_cairn_local_postgres
@@ -38,7 +38,7 @@ services:
     image: django_cairn_local_docs
     container_name: django_cairn_local_docs
     build:
-      context: django_cairn2
+      context: django_cairn
       dockerfile: compose/local/docs/Dockerfile
     env_file:
       - .envs/.local/.django

--- a/production.yml
+++ b/production.yml
@@ -9,7 +9,7 @@ volumes:
 services:
   django:
     build:
-      context: django_cairn
+      context: .
       dockerfile: compose/production/django/Dockerfile
 
     image: django_cairn_production_django
@@ -25,7 +25,7 @@ services:
 
   postgres:
     build:
-      context: django_cairn
+      context: .
       dockerfile: compose/production/postgres/Dockerfile
     image: django_cairn_production_postgres
     volumes:
@@ -36,7 +36,7 @@ services:
 
   traefik:
     build:
-      context: django_cairn
+      context: .
       dockerfile: compose/production/traefik/Dockerfile
     image: django_cairn_production_traefik
     depends_on:
@@ -51,7 +51,7 @@ services:
     image: redis:6
   nginx:
     build:
-      context: django_cairn
+      context: .
       dockerfile: compose/production/nginx/Dockerfile
     image: django_cairn_local_nginx
     depends_on:

--- a/production.yml
+++ b/production.yml
@@ -9,7 +9,7 @@ volumes:
 services:
   django:
     build:
-      context: django_cairn2
+      context: django_cairn
       dockerfile: compose/production/django/Dockerfile
 
     image: django_cairn_production_django
@@ -25,7 +25,7 @@ services:
 
   postgres:
     build:
-      context: django_cairn2
+      context: django_cairn
       dockerfile: compose/production/postgres/Dockerfile
     image: django_cairn_production_postgres
     volumes:
@@ -36,7 +36,7 @@ services:
 
   traefik:
     build:
-      context: django_cairn2
+      context: django_cairn
       dockerfile: compose/production/traefik/Dockerfile
     image: django_cairn_production_traefik
     depends_on:
@@ -51,7 +51,7 @@ services:
     image: redis:6
   nginx:
     build:
-      context: django_cairn2
+      context: django_cairn
       dockerfile: compose/production/nginx/Dockerfile
     image: django_cairn_local_nginx
     depends_on:

--- a/requirements/local.in
+++ b/requirements/local.in
@@ -1,4 +1,4 @@
--c production.txt
+-r production.txt
 
 Werkzeug[watchdog]
 ipdb

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -8,14 +8,24 @@ alabaster==0.7.13
     # via sphinx
 appnope==0.1.3
     # via ipython
+argon2-cffi==21.3.0
+    # via -r requirements/production.txt
+argon2-cffi-bindings==21.2.0
+    # via
+    #   -r requirements/production.txt
+    #   argon2-cffi
 asgiref==3.6.0
     # via
-    #   -c requirements/production.txt
+    #   -r requirements/production.txt
     #   django
 astroid==2.15.2
     # via pylint
 asttokens==2.2.1
     # via stack-data
+async-timeout==4.0.2
+    # via
+    #   -r requirements/production.txt
+    #   redis
 attrs==22.2.0
     # via pytest
 babel==2.12.1
@@ -26,13 +36,19 @@ build==0.10.0
     # via pip-tools
 certifi==2022.12.7
     # via
-    #   -c requirements/production.txt
+    #   -r requirements/production.txt
     #   requests
+    #   sentry-sdk
+cffi==1.15.1
+    # via
+    #   -r requirements/production.txt
+    #   argon2-cffi-bindings
+    #   cryptography
 cfgv==3.3.1
     # via pre-commit
 charset-normalizer==3.1.0
     # via
-    #   -c requirements/production.txt
+    #   -r requirements/production.txt
     #   requests
 click==8.1.3
     # via pip-tools
@@ -42,33 +58,65 @@ coverage==7.2.2
     # via
     #   -r requirements/local.in
     #   django-coverage-plugin
+crispy-bootstrap5==0.7
+    # via -r requirements/production.txt
+cryptography==40.0.1
+    # via
+    #   -r requirements/production.txt
+    #   pyjwt
 decorator==5.1.1
     # via
     #   ipdb
     #   ipython
+defusedxml==0.7.1
+    # via
+    #   -r requirements/production.txt
+    #   python3-openid
 dill==0.3.6
     # via pylint
 distlib==0.3.6
     # via virtualenv
 django==4.2
     # via
-    #   -c requirements/production.txt
+    #   -r requirements/production.txt
+    #   crispy-bootstrap5
+    #   django-allauth
+    #   django-anymail
+    #   django-crispy-forms
     #   django-debug-toolbar
     #   django-extensions
+    #   django-model-utils
+    #   django-redis
     #   django-stubs
     #   django-stubs-ext
+django-allauth==0.54.0
+    # via -r requirements/production.txt
+django-anymail==9.1
+    # via -r requirements/production.txt
 django-coverage-plugin==3.0.0
     # via -r requirements/local.in
+django-crispy-forms==2.0
+    # via
+    #   -r requirements/production.txt
+    #   crispy-bootstrap5
 django-debug-toolbar==4.0.0
     # via -r requirements/local.in
+django-environ==0.10.0
+    # via -r requirements/production.txt
 django-extensions==3.2.1
     # via -r requirements/local.in
+django-model-utils==4.3.1
+    # via -r requirements/production.txt
+django-redis==5.2.0
+    # via -r requirements/production.txt
 django-stubs==1.16.0
     # via -r requirements/local.in
 django-stubs-ext==0.8.0
     # via django-stubs
 docutils==0.19
     # via sphinx
+environ==1.0
+    # via -r requirements/production.txt
 exceptiongroup==1.1.1
     # via pytest
 executing==1.2.0
@@ -79,11 +127,15 @@ faker==18.3.2
     # via factory-boy
 filelock==3.10.7
     # via virtualenv
+gunicorn==20.1.0
+    # via -r requirements/production.txt
+hiredis==2.2.2
+    # via -r requirements/production.txt
 identify==2.5.22
     # via pre-commit
 idna==3.4
     # via
-    #   -c requirements/production.txt
+    #   -r requirements/production.txt
     #   requests
 imagesize==1.4.1
     # via sphinx
@@ -119,6 +171,10 @@ mypy-extensions==1.0.0
     # via mypy
 nodeenv==1.7.0
     # via pre-commit
+oauthlib==3.2.2
+    # via
+    #   -r requirements/production.txt
+    #   requests-oauthlib
 packaging==23.0
     # via
     #   build
@@ -131,6 +187,8 @@ pexpect==4.8.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
+pillow==9.5.0
+    # via -r requirements/production.txt
 pip-tools==6.12.3
     # via -r requirements/local.in
 platformdirs==3.2.0
@@ -145,16 +203,24 @@ prompt-toolkit==3.0.38
     # via ipython
 psycopg2==2.9.6
     # via
-    #   -c requirements/production.txt
     #   -r requirements/local.in
+    #   -r requirements/production.txt
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
+pycparser==2.21
+    # via
+    #   -r requirements/production.txt
+    #   cffi
 pygments==2.14.0
     # via
     #   ipython
     #   sphinx
+pyjwt[crypto]==2.6.0
+    # via
+    #   -r requirements/production.txt
+    #   django-allauth
 pylint==2.17.2
     # via
     #   pylint-django
@@ -176,12 +242,31 @@ pytest-sugar==0.9.6
     # via -r requirements/local.in
 python-dateutil==2.8.2
     # via faker
+python-slugify==8.0.1
+    # via -r requirements/production.txt
+python3-openid==3.2.0
+    # via
+    #   -r requirements/production.txt
+    #   django-allauth
 pyyaml==6.0
     # via pre-commit
+redis==4.5.4
+    # via
+    #   -r requirements/production.txt
+    #   django-redis
 requests==2.28.2
     # via
-    #   -c requirements/production.txt
+    #   -r requirements/production.txt
+    #   django-allauth
+    #   django-anymail
+    #   requests-oauthlib
     #   sphinx
+requests-oauthlib==1.3.1
+    # via
+    #   -r requirements/production.txt
+    #   django-allauth
+sentry-sdk==1.19.0
+    # via -r requirements/production.txt
 six==1.16.0
     # via
     #   livereload
@@ -208,13 +293,17 @@ sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
 sqlparse==0.4.3
     # via
-    #   -c requirements/production.txt
+    #   -r requirements/production.txt
     #   django
     #   django-debug-toolbar
 stack-data==0.6.2
     # via ipython
 termcolor==2.2.0
     # via pytest-sugar
+text-unidecode==1.3
+    # via
+    #   -r requirements/production.txt
+    #   python-slugify
 tomli==2.0.1
     # via
     #   build
@@ -244,8 +333,9 @@ typing-extensions==4.5.0
     #   mypy
 urllib3==1.26.15
     # via
-    #   -c requirements/production.txt
+    #   -r requirements/production.txt
     #   requests
+    #   sentry-sdk
 virtualenv==20.21.0
     # via pre-commit
 watchdog==3.0.0
@@ -256,6 +346,8 @@ werkzeug[watchdog]==2.2.3
     # via -r requirements/local.in
 wheel==0.40.0
     # via pip-tools
+whitenoise==6.4.0
+    # via -r requirements/production.txt
 wrapt==1.15.0
     # via astroid
 

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -50,7 +50,7 @@ dill==0.3.6
     # via pylint
 distlib==0.3.6
     # via virtualenv
-django==4.0.10
+django==4.2
     # via
     #   -c requirements/production.txt
     #   django-debug-toolbar

--- a/requirements/production.in
+++ b/requirements/production.in
@@ -8,6 +8,7 @@ argon2-cffi
 whitenoise
 redis
 hiredis
+environ
 django
 django-environ
 django-model-utils

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -28,7 +28,7 @@ cryptography==40.0.1
     # via pyjwt
 defusedxml==0.7.1
     # via python3-openid
-django==4.0.10
+django==4.2
     # via
     #   -r requirements/production.in
     #   crispy-bootstrap5
@@ -50,6 +50,8 @@ django-environ==0.10.0
 django-model-utils==4.3.1
     # via -r requirements/production.in
 django-redis==5.2.0
+    # via -r requirements/production.in
+environ==1.0
     # via -r requirements/production.in
 gunicorn==20.1.0
     # via -r requirements/production.in
@@ -82,7 +84,7 @@ requests==2.28.2
     #   requests-oauthlib
 requests-oauthlib==1.3.1
     # via django-allauth
-sentry-sdk==1.17.0
+sentry-sdk==1.19.0
     # via -r requirements/production.in
 sqlparse==0.4.3
     # via django


### PR DESCRIPTION
In my merging of a cookiecutter project template and the existing project, I had to rename a path. I didn't catch that PyCharm refactored the project as well. Since I didn't wait for CI to pass before merging, I missed this. I guess I need to go set that rule up too. Glad the first PR went well...